### PR TITLE
Symlink correctly in pass-fail

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -354,7 +354,11 @@ tc () {
       if [[ ${latestdir[$name]} == "$CURGROUP_DIR" ]]; then
         echo "Skipping duplicate case ${nicenames[$name]}"
       else
-        LN="ln -s ../../" # ln -sr isn't supported on Mac
+        if [[ $USE_SCORING = 0 ]]; then
+            LN="ln -s ../" # one lower level of nesting for non-scoring
+        else
+            LN="ln -s ../../" # ln -sr isn't supported on Mac
+        fi
         if [[ $USE_SYMLINKS = 0 ]]; then
           wait
           PARALLELISM_ACTIVE=1


### PR DESCRIPTION
Using symlinks with USE_SCORING=0 results in broken relative links.
There isn't really much reason to do this at all so I'd say either solve it like this or just report a clear error if test case reuse is used with USE_SCORING=0.