### PR TITLE
Code quality changes - Shellcheck

### DIFF
--- a/examples/arithmetic/data/generator.sh
+++ b/examples/arithmetic/data/generator.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-PPATH=$(realpath ..)
-. "$PPATH"/../../gen.sh
+# shellcheck source=/dev/null
+. ../../../gen.sh
 
 use_solution arithmetic.cpp
 

--- a/examples/arithmetic/data/sample/testdata.yaml
+++ b/examples/arithmetic/data/sample/testdata.yaml
@@ -2,4 +2,3 @@ on_reject: continue
 range: 0 0
 accept_score: 0
 grader_flags: first_error
-input_validator_flags: ab=1e9 c=1e9

--- a/examples/arithmetic/data/testdata.yaml
+++ b/examples/arithmetic/data/testdata.yaml
@@ -1,3 +1,3 @@
 on_reject: continue
-range: 0 100
+range: 0 0
 grader_flags: ignore_sample

--- a/examples/codforces/data/generator.sh
+++ b/examples/codforces/data/generator.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-PPATH=$(realpath ..)
-. "$PPATH"/../../gen.sh
+# shellcheck source=/dev/null
+. ../../../gen.sh
 
 ulimit -s unlimited
 

--- a/examples/lampswitches/data/generator.sh
+++ b/examples/lampswitches/data/generator.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-PPATH=$(realpath ..)
-. "$PPATH"/../../gen.sh
+# shellcheck source=/dev/null
+. ../../../gen.sh
 
 use_solution sl.cpp
 
@@ -74,9 +74,9 @@ wait
 if which dot >/dev/null; then
 	echo Creating visualizations...
 	for F in sample/*.in secret/group1/*.in; do
-		N=$(head -n 1 $F)
+		N=$(head -n 1 "$F")
 		if [[ $N -lt 25 ]]; then
-			./visualize.py <$F | dot -T png -o ${F%.in}.png
+			./visualize.py <"$F" | dot -T png -o "${F%.in}".png
 		fi
 	done
 fi

--- a/examples/ninetynine/data/empty.sh
+++ b/examples/ninetynine/data/empty.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/examples/ninetynine/data/generator.sh
+++ b/examples/ninetynine/data/generator.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-PPATH=$(realpath ..)
-. "$PPATH"/../../gen.sh
+# shellcheck source=/dev/null
+. ../../../gen.sh
 
 use_solution ../../data/empty.sh # empty .ans files
 
@@ -26,5 +26,5 @@ tc two-4 echo two
 group group3 40
 limits mode=random
 for A in {1..20}; do
-	tc random-$A echo random
+	tc random-"$A" echo random
 done

--- a/examples/ninetynine/data/testdata.yaml
+++ b/examples/ninetynine/data/testdata.yaml
@@ -1,3 +1,3 @@
-range: 0 100
 on_reject: continue
+range: 0 100
 grader_flags: ignore_sample

--- a/gen.sh
+++ b/gen.sh
@@ -370,8 +370,10 @@ tc () {
         fi
         local path
         path="$CURGROUP_DIR/$(_base "${cases[$name]}")"
-        "${LN}""${cases[$name]}".in "$path.in"
-        "${LN}""${cases[$name]}".ans "$path.ans"
+        # shellcheck disable=2086
+        ${LN}${cases[$name]}.in "$path.in"
+        # shellcheck disable=2086
+        ${LN}${cases[$name]}.ans "$path.ans"
         for ext in {hint,desc}; do
             if [ -f "${cases[$name]}"."$ext" ]; then
                 "${LN}""${cases[$name]}"."$ext" "$path.$ext"


### PR DESCRIPTION
I ran the code through shellcheck which is de facto standard static analysis tool for shell scripts.
I made the changes required to pass, only ignoring a few warnings for the special use cases.

Why did I do this?
We are using shellcheck and include testdata_tools in our repos for contests so the library got flagged.
For libraries it is important to make sure errors/warnings don't disrupt the experience of the library user.