### PR TITLE
Enforce sample numbering (controversial?)

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -55,6 +55,7 @@ declare -A cases
 declare -A latestdir
 declare -A nicenames
 declare -A groups
+declare -A sample_symlink_name
 declare -a cleanup
 
 _get_ext () {
@@ -212,6 +213,8 @@ sample () {
   solve "$path"
   CURTEST="$path"
   cases[$name]="$path"
+  sample_symlink_name[$name]="$(printf '%03d' $TC_INDEX)-$name"
+  let TC_INDEX++
   latestdir[$name]=sample
   nicenames[$name]="sample/$name"
   groups[sample]="${groups[sample]} $name"
@@ -235,6 +238,8 @@ sample_manual () {
   echo "Using manual solution for $path"
   CURTEST="$path"
   cases[$name]="$path"
+  sample_symlink_name[$name]="$(printf '%03d' $TC_INDEX)-$name"
+  let TC_INDEX++
   latestdir[$name]=sample
   nicenames[$name]="sample/$name"
   groups[sample]="${groups[sample]} $name"
@@ -364,7 +369,9 @@ tc () {
           PARALLELISM_ACTIVE=1
           LN="cp "
         fi
-        local path="$CURGROUP_DIR/$(_base ${cases[$name]})"
+        # To ensure correct order, the symlink names of samples are e.g. 001-sample01.in instead of just sample01.in
+        local basepath="${sample_symlink_name[$name]:-$(_base ${cases[$name]})}"
+        local path="$CURGROUP_DIR/$basepath"
         ${LN}${cases[$name]}.in "$path.in"
         ${LN}${cases[$name]}.ans "$path.ans"
         for ext in {hint,desc}; do


### PR DESCRIPTION
Closes https://github.com/Kodsport/testdata_tools/issues/25.

First, a minor sanity check: check that every .ans file in sample has a corresponding `.in` file.

For the controversial part: Kattis is now exposing more details about testcases in their UI.
<img width="1741" height="156" alt="image" src="https://github.com/user-attachments/assets/c8431f0d-74b8-444a-9be0-f02dc0474a7d" />

Here, it seems like the participant was 3 test cases off from AC. However, they are actually only one testcase off: the two testcases at the end are the sample, because i named them `1.in` and `2.in`. I think that this is somewhat common, and that the fix is to number samples.

Because `testdata_tools` uses sample both as the "input" and "output" folder for samples, we don't really have any choice but to rename the samples.

Thus, this is not backwards-compatible, in the sense that you if you use the new `gen.sh` on old problems, you will be forced to do some cleanup.

Sample run:
```sh
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/online/absolutbio/data$ rm -rf sample && git restore sample && ./generator.sh
ERROR: Some samples did not start with three digits followed by -
ERROR: Please change your samples to use the following the sample commands:
sample 001-1
sample 002-2
sample 003-3
sample 004-4
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/online/absolutbio/data$
```