### PR TITLE
Add -g when compiling with fsanitize

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -101,7 +101,7 @@ compile_cpp () {
   if [[ $2 == *"opt"* || "$(uname -s)" != Linux* ]]; then
     g++ -O2 -Wall -std=gnu++20 -DGENERATING_TEST_DATA -o $(_base $1) $1
   else
-    g++ -O2 -fsanitize=undefined -fsanitize=address -Wall -std=gnu++20 -DGENERATING_TEST_DATA -o $(_base $1) $1
+    g++ -O2 -fsanitize=undefined,address -g1 -Wall -std=gnu++20 -DGENERATING_TEST_DATA -o $(_base $1) $1
   fi
   add_program $(_base $1) "./$(_base $1)"
   add_cleanup $(_base $1)


### PR DESCRIPTION
I see no reason not to do it. Pretty nice to get line numbers when fsanitize crashes. It goes from
`#1 0x557e8aa68e68 in main (/home/matis/po-repos/<...>/data/joshuan2+0x15e68)`
to
`#2 0x556ed9309e68 in main /home/matis/po-repos/<...>/submissions/accepted/joshuan2.cpp:45`