### PR TITLE
Ensure group ordering in source matches Kattis' ordering

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -48,6 +48,7 @@ NOCOL='\033[0m'
 TOTAL_SCORE=0
 HAS_ERROR=0
 TC_INDEX=1
+PREV_GROUP_NAME=
 
 
 declare -A programs
@@ -250,6 +251,10 @@ group () {
   _assert_scoring group
   CURGROUP_NAME="$1"
   CURGROUP_DIR="secret/$1"
+  if [[ -n "$PREV_GROUP_NAME" && $(printf '%s\n%s\n' "$1" "$PREV_GROUP_NAME" | LC_ALL=C sort | head -1) != "$PREV_GROUP_NAME" ]]; then
+    _error "group name \"$1\" does not come after \"$PREV_GROUP_NAME\" in lexicographic order and will appear out of order in Kattis. Either prefix with group index or rename."
+  fi
+  PREV_GROUP_NAME="$1"
   echo 
   echo -e "Group $CURGROUP_NAME"
   mkdir "$CURGROUP_DIR"


### PR DESCRIPTION
Closes #26. 

Example error messages:
`ERROR: group name "linear" does not come after "quadratic" in lexicographic order and will appear out of order in Kattis. Either prefix with group index or rename.`

For this generator:
```
group quadratic 50
include_group sample

group linear 50
include_group quadratic
```

`ERROR: group name "group10" does not come after "group2" in lexicographic order and will appear out of order in Kattis. Either prefix with group index or rename.`

with generator
```
group group1 50
include_group sample

group group2 50
include_group group1

group group10 50
include_group group2
```