### PR TITLE
Make tg_manual handle identical test cases

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -461,7 +461,14 @@ tg_manual() {
   fi
 
   for infile in "${infiles[@]}"; do
-    tc_manual "$infile"
+    local name
+    name=$(_base "$infile")
+    if [[ ${cases[$name]} != "" ]]; then
+      # Case already exists from an earlier group, reuse it
+      tc "$name"
+    else
+      tc_manual "$infile"
+    fi
   done
 }
 


### PR DESCRIPTION
If you call `tg_manual` on the same folder twice, you will be spammed with errors.
Let's instead reuse them properly using `tc`.