### PR TITLE
Add standardized output validator header

### DIFF
--- a/output_validators/validator/validate.cc
+++ b/output_validators/validator/validate.cc
@@ -1,0 +1,82 @@
+#include "validate.h"
+
+// Example validator for the task:
+// Given an undirected graph, is there an even-length cycle?
+// If so, find one
+
+#include <bits/stdc++.h>
+using namespace std;
+
+#define rep(i, a, b) for(int i = a; i < (b); ++i)
+#define all(x) begin(x), end(x)
+#define sz(x) (int)(x).size()
+using ll = long long;
+using pii = pair<int, int>;
+using vi = vector<int>;
+
+int main(int argc, char **argv) {
+    init_io(argc, argv);
+
+    int n, m;
+    judge_in >> n >> m;
+
+    set<pii> edges;
+    rep(i,0,m) {
+        int a, b;
+        judge_in >> a >> b;
+        edges.emplace(a,b);
+        edges.emplace(b,a);
+    }
+
+    auto check = [&](istream& sol, feedback_function feedback) {
+        string ans;
+        if (!(sol >> ans)) feedback("Expected more output");
+        for (char& c : ans) c = tolower(c);
+        if (ans != "no" && ans != "yes") {
+            feedback("Answer is not {yes|no}");
+        }
+
+        if (ans == "no") {
+            string trailing;
+            if (sol >> trailing) feedback("Trailing output");
+            return false;
+        }
+
+        int k;
+        if (!(sol >> k)) feedback("Expected more output");
+        if (k < 4 || k > n) feedback("Cycle length is out of range");
+        if (k % 2 != 0) feedback("Cycle length is odd");
+
+        vi seen(n+1,0);
+        vi c;
+        rep(i,0,k) {
+            int x;
+            if(!(sol >> x)) feedback("Expected more output");
+            if(x < 1 || x > n) feedback("Vertex index is out of range");
+            if(seen[x]) feedback("Duplicate vertex in cycle");
+            c.emplace_back(x);
+            seen[x] = 1;
+        }
+
+        rep(i,0,k) if (!edges.count(pii(c[i], c[(i+1)%k]))) {
+            feedback("Edge used in cycle does not exist");
+        }
+
+        string trailing;
+        if(sol >> trailing) feedback("Trailing output");
+        return true;
+    };
+
+    bool judge_found_sol = check(judge_ans, judge_error);
+    bool author_found_sol = check(author_out, wrong_answer);
+
+    if(!judge_found_sol && author_found_sol) {
+        judge_error("NO! Solution found a cycle, but judge says none exists");
+    }
+
+    if(judge_found_sol && !author_found_sol) {
+        wrong_answer("Cycle exists, but solution did not find it");
+    }
+
+    accept();
+}

--- a/output_validators/validator/validate.h
+++ b/output_validators/validator/validate.h
@@ -1,0 +1,153 @@
+/* Utility functions for writing output validators for the Kattis
+ * problem format.
+ *
+ * The primary functions and variables available are the following.
+ * In many cases, the only functions needed are "init_io",
+ * "wrong_answer", and "accept".
+ *
+ * - init_io(argc, argv):
+ *        initialization
+ *
+ * - judge_in, judge_ans, author_out:
+ *        std::istream objects for judge input file, judge answer
+ *        file, and submission output file.
+ *
+ * - accept():
+ *        exit and give Accepted!
+ *
+ * - accept_with_score(double score):
+ *        exit with Accepted and give a score (for scoring problems)
+ *
+ * - judge_message(std::string msg, ...):
+ *        printf-style function for emitting a judge message (a
+ *        message that gets displayed to a privileged user with access
+ *        to secret data etc).
+ *
+ * - wrong_answer(std::string msg, ...):
+ *        printf-style function for exitting and giving Wrong Answer,
+ *        and emitting a judge message (which would typically explain
+ *        the cause of the Wrong Answer)
+ *
+ * - judge_error(std::string msg, ...):
+ *        printf-style function for exitting and giving Judge Error,
+ *        and emitting a judge message (which would typically explain
+ *        the cause of the Judge Error)
+ *
+ * - author_message(std::string msg, ...):
+ *        printf-style function for emitting an author message (a
+ *        message that gets displayed to the author of the
+ *        submission).  (Use with caution, and be careful not to let
+ *        it leak information!)
+ *
+ */
+#pragma once
+
+#include <sys/stat.h>
+#include <cassert>
+#include <cstdarg>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+typedef void (*feedback_function)(const char*, ...);
+
+const int EXITCODE_AC = 42;
+const int EXITCODE_WA = 43;
+const char* FILENAME_AUTHOR_MESSAGE = "teammessage.txt";
+const char* FILENAME_JUDGE_MESSAGE = "judgemessage.txt";
+const char* FILENAME_JUDGE_ERROR = "judgeerror.txt";
+const char* FILENAME_SCORE = "score.txt";
+
+#define USAGE "%s: judge_in judge_ans feedback_dir < author_out\n"
+
+std::ifstream judge_in, judge_ans;
+std::istream author_out(std::cin.rdbuf());
+
+char *feedbackdir = NULL;
+
+void vreport_feedback(const char* category,
+                      const char* msg,
+                      va_list pvar) {
+    std::ostringstream fname;
+    if (feedbackdir)
+        fname << feedbackdir << '/';
+    fname << category;
+    FILE *f = fopen(fname.str().c_str(), "a");
+    assert(f);
+    vfprintf(f, msg, pvar);
+    fclose(f);
+}
+
+void report_feedback(const char* category, const char* msg, ...) {
+    va_list pvar;
+    va_start(pvar, msg);
+    vreport_feedback(category, msg, pvar);
+}
+
+void author_message(const char* msg, ...) {
+    va_list pvar;
+    va_start(pvar, msg);
+    vreport_feedback(FILENAME_AUTHOR_MESSAGE, msg, pvar);
+}
+
+void judge_message(const char* msg, ...) {
+    va_list pvar;
+    va_start(pvar, msg);
+    vreport_feedback(FILENAME_JUDGE_MESSAGE, msg, pvar);
+}
+
+void wrong_answer(const char* msg, ...) {
+    va_list pvar;
+    va_start(pvar, msg);
+    vreport_feedback(FILENAME_JUDGE_MESSAGE, msg, pvar);
+    exit(EXITCODE_WA);
+}
+
+void judge_error(const char* msg, ...) {
+    va_list pvar;
+    va_start(pvar, msg);
+    vreport_feedback(FILENAME_JUDGE_ERROR, msg, pvar);
+    assert(0);
+}
+
+void accept() {
+    exit(EXITCODE_AC);
+}
+
+void accept_with_score(double scorevalue) {
+    report_feedback(FILENAME_SCORE, "%.9le", scorevalue);
+    exit(EXITCODE_AC);
+}
+
+
+bool is_directory(const char *path) {
+    struct stat entry;
+    return stat(path, &entry) == 0 && S_ISDIR(entry.st_mode);
+}
+
+void init_io(int argc, char **argv) {
+    if(argc < 4) {
+        fprintf(stderr, USAGE, argv[0]);
+        judge_error("Usage: %s judgein judgeans feedbackdir [opts] < userout", argv[0]);
+    }
+
+    // Set up feedbackdir first, as that allows us to produce feedback
+    // files for errors in the other parameters.
+    if (!is_directory(argv[3])) {
+        judge_error("%s: %s is not a directory\n", argv[0], argv[3]);
+    }
+    feedbackdir = argv[3];
+
+    judge_in.open(argv[1], std::ios_base::in);
+    if (judge_in.fail()) {
+        judge_error("%s: failed to open %s\n", argv[0], argv[1]);
+    }
+
+    judge_ans.open(argv[2], std::ios_base::in);
+    if (judge_ans.fail()) {
+        judge_error("%s: failed to open %s\n", argv[0], argv[2]);
+    }
+
+    author_out.rdbuf(std::cin.rdbuf());
+}

--- a/output_validators/validator/validate.h
+++ b/output_validators/validator/validate.h
@@ -18,22 +18,22 @@
  * - accept_with_score(double score):
  *        exit with Accepted and give a score (for scoring problems)
  *
- * - judge_message(std::string msg, ...):
+ * - judge_message(const char* msg, ...):
  *        printf-style function for emitting a judge message (a
  *        message that gets displayed to a privileged user with access
  *        to secret data etc).
  *
- * - wrong_answer(std::string msg, ...):
+ * - wrong_answer(const char* msg, ...):
  *        printf-style function for exitting and giving Wrong Answer,
  *        and emitting a judge message (which would typically explain
  *        the cause of the Wrong Answer)
  *
- * - judge_error(std::string msg, ...):
+ * - judge_error(const char* msg, ...):
  *        printf-style function for exitting and giving Judge Error,
  *        and emitting a judge message (which would typically explain
  *        the cause of the Judge Error)
  *
- * - author_message(std::string msg, ...):
+ * - author_message(const char* msg, ...):
  *        printf-style function for emitting an author message (a
  *        message that gets displayed to the author of the
  *        submission).  (Use with caution, and be careful not to let


### PR DESCRIPTION
I think we should centralize where we pull in the `validate.h` header from. This makes it easier to push changes to it, and allows there to exist a "canonical" version, making it easier to diff ad-hoc changes against.

Besides, I think that writing the output validator as is done in this example is highly desirable. I have encountered less experienced judges simply check that the value of a construction is equal to the judge solution's value, and only write a single solution. 