### PR TITLE
Always reset root's testdata.yaml

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -484,6 +484,7 @@ include_group () {
 # Initialization and cleanup code, automatically included.
 _setup_dirs () {
   rm -rf secret
+  rm -f testdata.yaml
   mkdir -p sample secret
   if [[ $USE_SCORING == 1 ]]; then
     echo "on_reject: continue


### PR DESCRIPTION
If `USE_SCORING=0` and limits is used, it appends without resetting, leading to duplicate `input_validator_flags` keys. I would assume `output_validator_flags` is similarly broken.

For scoring problems, this change shouldn't do anything different. For pass-fail problems, this means that hand-modified `data/testdata.yaml` will break. But why do that anyway? I would much prefer they just echo into it in the generator so it's reproducible.